### PR TITLE
Fix Terraform Errors and Add DNS Validation for App Runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
@@ -39,3 +39,5 @@ terraform.rc
 terraform.log
 
 .DS_Store
+
+.env*

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 module "langfuse" {
-  source             = "../../modules/langfuse"
+  source             = "../modules/langfuse"
   env                = "dev"
   identity_name      = "tubone24"
   region             = var.region
@@ -10,6 +10,6 @@ module "langfuse" {
   web_next_secret    = "generated-base64"
   web_salt           = "generated-base64"
   encryption_key     = "generated-hex-key"
-  custom_domain_id   = aws_route53_zone.example-com.id
-  custom_domain_name = aws_route53_zone.example-com.name
+  custom_domain_id   = data.aws_route53_zone.example-com.id
+  custom_domain_name = data.aws_route53_zone.example-com.name
 }

--- a/modules/langfuse/app_runner.tf
+++ b/modules/langfuse/app_runner.tf
@@ -151,3 +151,38 @@ resource "aws_apprunner_custom_domain_association" "grafana" {
   domain_name = "grafana.${var.custom_domain_name}"
   service_arn = aws_apprunner_service.grafana.arn
 }
+
+data "aws_route53_zone" "custom_domain" {
+  name = "${var.custom_domain_name}."
+}
+
+resource "aws_route53_record" "certificate_validation_grafana" {
+  for_each = {
+    for record in aws_apprunner_custom_domain_association.grafana.certificate_validation_records : record.name => {
+      name   = record.name
+      record = record.value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.custom_domain.zone_id
+  name    = each.value.name
+  type    = "CNAME"
+  ttl     = "300"
+  records = [each.value.record]
+}
+
+resource "aws_route53_record" "certificate_validation_langfuse" {
+  for_each = {
+    for record in aws_apprunner_custom_domain_association.langfuse.certificate_validation_records : record.name => {
+      name   = record.name
+      record = record.value
+    }
+  }
+
+  zone_id = data.aws_route53_zone.custom_domain.zone_id
+  name    = each.value.name
+  type    = "CNAME"
+  ttl     = "300"
+  records = [each.value.record]
+}
+  

--- a/modules/langfuse/ecr.tf
+++ b/modules/langfuse/ecr.tf
@@ -1,6 +1,7 @@
 resource "aws_ecr_repository" "langfuse_web" {
   name                 = "langfuse-web"
   image_tag_mutability = "MUTABLE"
+  force_delete         = var.force_delete
 
   image_scanning_configuration {
     scan_on_push = true
@@ -34,6 +35,7 @@ resource "aws_ecr_lifecycle_policy" "image_count_cleanup_langfuse_web" {
 resource "aws_ecr_repository" "langfuse_worker" {
   name                 = "langfuse-worker"
   image_tag_mutability = "MUTABLE"
+  force_delete         = var.force_delete
 
   image_scanning_configuration {
     scan_on_push = true
@@ -67,6 +69,7 @@ resource "aws_ecr_lifecycle_policy" "image_count_cleanup_langfuse_worker" {
 resource "aws_ecr_repository" "clickhouse" {
   name                 = "clickhouse"
   image_tag_mutability = "MUTABLE"
+  force_delete         = var.force_delete
 
   image_scanning_configuration {
     scan_on_push = true
@@ -100,6 +103,7 @@ resource "aws_ecr_lifecycle_policy" "image_count_cleanup_clickhouse" {
 resource "aws_ecr_repository" "grafana" {
   name                 = "grafana"
   image_tag_mutability = "MUTABLE"
+  force_delete         = var.force_delete
 
   image_scanning_configuration {
     scan_on_push = true

--- a/modules/langfuse/rds.tf
+++ b/modules/langfuse/rds.tf
@@ -18,7 +18,7 @@ resource "aws_rds_cluster" "langfuse_aurora_cluster" {
   master_password     = aws_secretsmanager_secret_version.langfuse_db_password.secret_string
   storage_encrypted   = true
   kms_key_id          = aws_kms_key.postgres.arn
-  deletion_protection = true
+  deletion_protection = !var.force_delete
 
   backup_retention_period         = 5
   preferred_backup_window         = "07:00-09:00"

--- a/modules/langfuse/rds.tf
+++ b/modules/langfuse/rds.tf
@@ -13,7 +13,7 @@ resource "aws_rds_cluster" "langfuse_aurora_cluster" {
   engine_version      = "15.6"
   engine_mode         = "provisioned"
   availability_zones  = var.availability_zones
-  database_name       = "langfuse_db"
+  database_name       = "langfuse"
   master_username     = var.database_user
   master_password     = aws_secretsmanager_secret_version.langfuse_db_password.secret_string
   storage_encrypted   = true

--- a/modules/langfuse/s3.tf
+++ b/modules/langfuse/s3.tf
@@ -1,7 +1,9 @@
 resource "aws_s3_bucket" "langfuse_blob" {
-  bucket = "${var.identity_name}-langfuse-blob-${var.env}"
+  bucket        = "${var.identity_name}-langfuse-blob-${var.env}"
+  force_destroy = var.force_delete
 }
 
 resource "aws_s3_bucket" "langfuse_event" {
-  bucket = "${var.identity_name}-langfuse-event-${var.env}"
+  bucket        = "${var.identity_name}-langfuse-event-${var.env}"
+  force_destroy = var.force_delete
 }

--- a/modules/langfuse/secrets_manager.tf
+++ b/modules/langfuse/secrets_manager.tf
@@ -19,7 +19,7 @@ resource "aws_secretsmanager_secret" "langfuse_database_url" {
 
 resource "aws_secretsmanager_secret_version" "langfuse_database_url" {
   secret_id     = aws_secretsmanager_secret.langfuse_database_url.arn
-  secret_string = "postgresql://root:${aws_secretsmanager_secret_version.langfuse_db_password.secret_string}@${aws_rds_cluster.langfuse_aurora_cluster.endpoint}:5432/langfuse"
+  secret_string = "postgresql://${var.database_user}:${aws_secretsmanager_secret_version.langfuse_db_password.secret_string}@${aws_rds_cluster.langfuse_aurora_cluster.endpoint}:5432/langfuse"
 }
 
 

--- a/modules/langfuse/secrets_manager.tf
+++ b/modules/langfuse/secrets_manager.tf
@@ -5,7 +5,7 @@ resource "random_password" "langfuse_db_password" {
 }
 
 resource "aws_secretsmanager_secret" "langfuse_db_password" {
-  name = "langfuse_database_password"
+  name_prefix = "langfuse_database_password"
 }
 
 resource "aws_secretsmanager_secret_version" "langfuse_db_password" {
@@ -14,7 +14,7 @@ resource "aws_secretsmanager_secret_version" "langfuse_db_password" {
 }
 
 resource "aws_secretsmanager_secret" "langfuse_database_url" {
-  name = "langfuse_database_url"
+  name_prefix = "langfuse_database_url"
 }
 
 resource "aws_secretsmanager_secret_version" "langfuse_database_url" {
@@ -30,7 +30,7 @@ resource "random_password" "clickhouse_password" {
 }
 
 resource "aws_secretsmanager_secret" "clickhouse_password" {
-  name = "clickhouse_password"
+  name_prefix = "clickhouse_password"
 }
 
 resource "aws_secretsmanager_secret_version" "clickhouse_password" {
@@ -45,7 +45,7 @@ resource "random_password" "grafana_admin_password" {
 }
 
 resource "aws_secretsmanager_secret" "grafana_admin_password" {
-  name = "grafana_admin_password"
+  name_prefix = "grafana_admin_password"
 }
 
 resource "aws_secretsmanager_secret_version" "grafana_admin_password" {

--- a/modules/langfuse/security_group.tf
+++ b/modules/langfuse/security_group.tf
@@ -53,8 +53,8 @@ resource "aws_security_group" "langfuse_cache" {
   }
 
   ingress {
-    from_port       = 6379
-    to_port         = 6379
+    from_port       = 0
+    to_port         = 0
     protocol        = "-1"
     security_groups = [aws_security_group.apprunner_vpc_connector.id, aws_security_group.langfuse_db.id, aws_security_group.langfuse_worker.id]
     description     = "Ingress Allow all traffic from app and flower security groups"

--- a/modules/langfuse/variables.tf
+++ b/modules/langfuse/variables.tf
@@ -91,3 +91,9 @@ variable "database_min_capacity" {
   type        = number
   default     = 0.5
 }
+
+variable "force_delete" {
+  description = "Whether to force delete resources"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
# Overview

During the execution of `terraform apply` and the Langfuse startup sequence, several errors occurred. These have been addressed and fixed.  
Additionally, for App Runner custom domains, manual DNS validation was previously required. This has now been implemented in Terraform.

# Details

The primary issues where errors occurred were as follows:

1. **Errors during `terraform plan` execution**  
    - In the sample implementation under `example`, there were inconsistencies in paths and data resource references.
2. **Errors in the Security Group and PostgreSQL configuration**

Moreover, during testing, it became necessary to repeatedly execute apply and destroy. To facilitate this process, adjustments were made around `force_{delete,destroy}`.

# Verified Items

- Grafana and Langfuse can be accessed via the custom domain.  
- Application logs in CloudWatch Logs do not contain any entries indicative of errors.


Thank you for publishing the Terraform module for Langfuse. With the move to version 3, the architecture has become more complex, and while I attempted to implement it myself, I struggled with many challenges along the way. Your module has been an enormous help for me.